### PR TITLE
supplementary details

### DIFF
--- a/docs/ww-customization.mdx
+++ b/docs/ww-customization.mdx
@@ -29,6 +29,13 @@ If there are files in your cloned version that are not in the tree below, you do
 |                   +-- options.json
 |                   +-- pronouns.json
 |                   +-- verbs.json
+|                       +-- i18n
+|                           +-- en.json
+|                           +-- fr.json
+|               +-- yourlang
+|                   +-- __init__.py
+|                   +-- models.py
+|                       +-- i18n
 |           +-- router
 |           +-- main.py
 |           +-- models.py
@@ -48,26 +55,31 @@ When deploying just to a development environment (the default) there is only one
 
 This is the main configurable service. It is the `wordweaver` Python package and API.
 
- Every WordWeaver has its data separated into 4 main sections: [Verbs](#verbs), [Pronouns](#pronouns), [Options](#options), and [Conjugations](#conjugations). This data must be in JSON format. To add your data, create a new folder in src/wordweaver/data named after your languages’s ISO 639-3 code. You will need to add 6 files: the described JSON data files, a blank __init__.py file, and a [models](#models) file. The following sections describe the data and models files.
+Every WordWeaver has its data separated into 4 main sections: [Verbs](#verbs), [Pronouns](#pronouns), [Options](#options), and [Conjugations](#conjugations). This data must be in JSON format. To add your data, create a new folder in `src/wordweaver/data` named after your languages’s [ISO 639-3 code](https://iso639-3.sil.org/code_tables/639/data). You will need to add 6 files: the described JSON data files, a blank \_\_init\_\_.py file, and a [models](#models) file. The following sections describe the data and models files.
 
-### Models
+In order for your data to be used when ran, you must change the variable WWLANG in the file `src/env-backend.env` to your languages’s [ISO 639-3 code](https://iso639-3.sil.org/code_tables/639/data). For example, to use the french data, it must read as follows:
+ 
+       `WWLANG=fr`
 
-Your models.py file is found at `src/wordweaver/data/<yourlang>/models.py` and should contain a model for each data file ([Verbs](#verbs), [Pronouns](#pronouns), [Options](#options), and [Conjugations](#conjugations)). If your data does vary from the default that’s been described, you will have to update the associated model.
 
-For example, if you wanted to include  a "gender" attribute to your "pronoun" data, you would have to up the pronoun model as follows
+__Note__: There is a default folder included in the initial downloaded, called `src/wordweaver/data/yourlang`. This folder contains the default models.py file (exactly as described below) and an empty \_\_init\_\_.py file. You may also instead rename this folder after your languages’s ISO 639-3 code and add your JSON data files there.
 
-```typescript {2}
-class Pronoun(BaseModel):
-   ''' Required '''
-   gender: str = ''
-   tag: str = ''
-```
+__Note__: There is a french wordweaver included in the initial downloaded, called `src/wordweaver/data/fr`. Feel free to explore this folder for reference or to copy code.
 
-If your data does not vary from the described defaults, the include default models.py file will contain all sufficient information and can be left untouched.
+## Language Data
+First, we will describe the data structures and files you will need to build. 
 
 ### Verbs
 
-You must have data related to the verb roots available in your WordWeaver in a single `verbs.json` file. Your verbs should be a JSON array of objects. Minimally, each verb in your verbs array **must** have a unique`tag`, and `classes` keys. 
+You must have data related to the verb roots available in your WordWeaver in a `verbs.json` file. Your verbs should be a JSON array of objects. Minimally, each verb in your verbs array **must** have a unique`tag` and a `classes` key. 
+
+#### tag
+
+The `tag` is the unique identifier for that verb. It must also be URL friendly, otherwise known as a [slug](https://stackoverflow.com/questions/19335215/what-is-a-slug). To be URL friendly, a slug must be restricted to [certain characters](https://stackoverflow.com/questions/1547899/which-characters-make-a-url-invalid)
+
+#### classes
+
+The `classes` key is an array of strings that are CSS class names to apply to that verb. This can be used to distinguish different verb types to the user. For more information, please visit the [WordWeaver UI style customization guide](ww-ui-style#custom-css).
 
 Default Definition:
 
@@ -76,19 +88,32 @@ class Verb(BaseModel):
     ''' Required '''
     tag: str = ''
     classes: List[str] = []
-``` 
+```  
+<sub>Source: `src/wordweaver/data/<yourlang>/models.py`</sub>
 
-#### tag
+For example, the verbs JSON file should be of the following form:
 
-The `tag` is the unique identifier for that verb. It must also be URL friendly, otherwise known as a [slug](https://stackoverflow.com/questions/19335215/what-is-a-slug). To be URL friendly, a slug must be restricted to [certain characters](https://stackoverflow.com/questions/1547899/which-characters-make-a-url-invalid)
+```json
+[
+   {
+       "tag":"aller",
+       "en": 
+            {
+                 "tag": "go"
+            },
+   }
+]
+```
+<sub>Source: `src/wordweaver/data/<yourlang>/verbs.json`</sub>
 
-#### classes
-
-The `classes` key is an array of strings that are CSS class names to apply to that verb. Please visit the [WordWeaver UI style customization guide](ww-ui-style#custom-css) for more information.
 
 ### Pronouns
 
-You must have data related to the pronouns available in your WordWeaver in a single `pronouns.json` file.
+You must have data related to pronouns available in your WordWeaver in a `pronouns.json` file. Your pronouns should be a JSON array of objects. Minimally, each pronoun in your pronoun array **must** have a unique`tag` and the JSON file must include both the `tag` and a display form (i.e. what the user will see). The default for the pronouns is to accept only a `subject`. To include an `object`, it should be included in the pronouns JSON file and the [Conjugations](#conjugations) related models must be updated as well (see section for details).
+
+#### tag
+
+The `tag` is the unique identifier for that pronoun. It must also be URL friendly, otherwise known as a [slug](https://stackoverflow.com/questions/19335215/what-is-a-slug). To be URL friendly, a slug must be restricted to [certain characters](https://stackoverflow.com/questions/1547899/which-characters-make-a-url-invalid)
 
 Default Definition:
 
@@ -97,14 +122,35 @@ class Pronoun(BaseModel):
     ''' Required '''
     tag: str = ''
 ```
+<sub>Source: `src/wordweaver/data/<yourlang>/models.py`</sub>
+ 
+ 
+For example, the pronouns JSON file should be of the following form:
 
-#### tag
-
-The `tag` is the unique identifier for that pronoun. It must also be a [slug](https://stackoverflow.com/questions/19335215/what-is-a-slug).
+```json
+[
+   {
+       "tag":"1SG",
+       "en": 
+            {
+                 "subject": "I"
+            },
+   }
+]
+```
+<sub>Source: `src/wordweaver/data/<yourlang>/pronouns.json`</sub>
 
 ### Options
 
-The 'Options' category is a catch-all category for all other types of information associated with choosing a conjugation. You therefore must have all other options related to your data available in a single `options.json` file.
+The 'Options' category is a catch-all category for all other types of information associated with choosing a conjugation. You must have data related to the options available in your WordWeaver in a single `options.json` file. Your options should be a JSON array of objects. Minimally, each option in your options array **must** have a unique`tag`. The JSON file must the unique `tag` and a display form (i.e. what the user will see). The default model also includes an optional `type` attribute.
+
+#### tag
+
+The `tag` is the unique identifier for that option. It must also be URL friendly, otherwise known as a [slug](https://stackoverflow.com/questions/19335215/what-is-a-slug). To be URL friendly, a slug must be restricted to [certain characters](https://stackoverflow.com/questions/1547899/which-characters-make-a-url-invalid).
+
+#### type
+
+The `type` allows for categorization of options (ex. tense, aspect etc)
 
 Default Definition:
 
@@ -114,14 +160,24 @@ class Option(BaseModel):
     tag: str = ''
     type: str = ''
 ```
+<sub>Source: `src/wordweaver/data/<yourlang>/models.py`</sub>
+ 
+ For example, the options JSON file should be of the following form:
 
-#### tag
+```json
+[
+   {
+       "tag": "indicatif-present",
+       "type": "indicatif",
+       "en": 
+            {
+                 "type": "Indicative"
+            },
+   }
+]
+```
+<sub>Source: `src/wordweaver/data/<yourlang>/options.json`</sub>
 
-The `tag` is the unique identifier for that option. It must also be a [slug](https://stackoverflow.com/questions/19335215/what-is-a-slug).
-
-#### type
-
-The `type` allows for categorization of options (ex. tense, aspect etc)
 
 ### Conjugations
 
@@ -134,15 +190,18 @@ class ResponseObject(BaseModel):
     input: ConjugationInput
     output: Conjugation
 ```
+<sub>Source: `src/wordweaver/data/<yourlang>/models.py`</sub>
 
-The `input` is an object that includes the tag values for each related `verb`, `pronoun`, and `option`:
+The `input` is an object that includes the tag values for each related `verb`, `pronoun`, and `option`. __Note__ that the default ConjugationInput class assumes _only_ a subject is required for any given conjugation. If your language's conjugations may require an `object`, please be sure to add an `object` attribute to this model. 
 
 ```python
 class ConjugationInput(BaseModel):
     root: str
     option: str
-    agent: str
+    subject: str
 ```
+<sub>Source: `src/wordweaver/data/<yourlang>/models.py`</sub>
+
 
 The `output` is a list of objects containing response morphemes:
 
@@ -158,10 +217,83 @@ class ResponseMorpheme(BaseModel):
     english: Optional[str]
     type: Optional[List[str]]
 ```
+<sub>Source: `src/wordweaver/data/<yourlang>/models.py`</sub>
 
 Response morphemes are units that can be concatenated into `Tiers`. Tiers are [defined in the WordWeaver UI](#ww-ui-customization#tiers).
 
-### Edit CORS rules
+For example, the conjugations JSON file should be of the following form:
+
+```json
+{
+    "input": {
+        "root": "courir",
+        "option": "indicatif-present",
+        "subject": "2-pl"
+    },
+    "output": [
+        {
+            "position": 0,
+            "value": "cour",
+            "type": [
+                "root"
+            ]
+        },
+        {
+            "position": 1,
+            "value": "ez",
+            "type": [
+                "ending"
+            ]
+        }
+    ]
+}
+```
+<sub>Source: `src/wordweaver/data/<yourlang>/conjugations.json`</sub>
+
+Here, `courir` must be a tag of a verb defined in `verbs.json`. `indicatif-present` must be a tag of an option defined in `options.json` and `2-pl` must be a tag of a pronoun defined in `pronouns.json`.
+
+If your language data is not available split up into morphemes, instead put the full value in position 0. 
+
+### Models
+
+Your models.py file is found at `src/wordweaver/data/<yourlang>/models.py` and should contain a model for each data file ([Verbs](#verbs), [Pronouns](#pronouns), [Options](#options), and [Conjugations](#conjugations)). If your data does vary from the default that’s been described, you will have to update the associated model.
+
+For example, if you wanted to include  a "gender" attribute to your "pronoun" data, you would have to up the pronoun model as follows
+
+```typescript {2}
+class Pronoun(BaseModel):
+   ''' Required '''
+   gender: str = ''
+   tag: str = ''
+```
+<sub>Source: `src/wordweaver/data/<yourlang>/models.py`</sub>
+
+If your data does not vary from the described defaults, the included default models.py file will contain all sufficient information and can be left untouched.
+
+### Internationalization - Including Other Languages
+
+The current front end in it's entirety is translated available in both English and French. To include translations for the entire website in another language, see [Internationalization] (link).
+
+Note that for all JSON files described in this section, the default display forms are expected in english. To include display forms in other languages, at this step you should similarily include those translations under the languages’s ISO 639-3 code. For example, if you wanted to include French display forms for your data, your pronouns should look as follows: 
+
+```json
+[
+   {
+       "tag":"1SG",
+       "en": 
+            {
+                 "subject": "I"
+            },
+       "fr": 
+            {
+                 "subject": "Je"
+            }
+   }
+]
+```
+<sub>Source: `src/wordweaver/data/<yourlang>/pronouns.json`</sub>
+
+## Edit CORS rules
 
 [Cross-origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (CORS) rules are defined in `src/wordweaver/main.py`. You can edit allowable [origins](https://en.wikipedia.org/wiki/Same-origin_policy#:~:text=An%20origin%20is%20defined%20as,that%20page's%20Document%20Object%20Model.), [methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) and [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) here.
 


### PR DESCRIPTION
## Main Changes:

### Each data description contains a JSON example. This includes moving the JSON example of the conjugation from the UI config to here.

* The JSON examples should be revised to make sure they're correct.

### Updating the tree to be how the default download should be (french example and `yourlang` default folder).

* I'll simultaneously be submitting the folder that matches this description

### Models moved to the end

* I think order makes more sense to understand all the data structure before understanding how to change them. Also because asides from changing, it's not the initial step the maker will take

### All code chunks are sourced

### Adding a section re: Internationalization - Including Other Languages

* Having the main internationalization guide is useful but it should also be sprinkled in in steps so that the maker does not have to go back and remake data if they already have multiple translations.

## Required for Review

* The JSON examples should be revised to make sure they're correct.
* Probably spell check, many of these words stopped having meaning in my brain head after a while.
* General fact checking
